### PR TITLE
foreign key error

### DIFF
--- a/oracle/sampledb/v1/schema/sport_location.tab
+++ b/oracle/sampledb/v1/schema/sport_location.tab
@@ -19,7 +19,7 @@ create sequence sport_location_seq
 
 
 create table sport_location
-(ID NUMBER(3) NOT NULL,
+(ID NUMBER NOT NULL,
  name varchar2(60) NOT NULL,
  city varchar2(60) NOT NULL,
  seating_capacity NUMBER(7),


### PR DESCRIPTION
```
ALTER TABLE dms_sample.seat
ADD CONSTRAINT s_sport_location_fk FOREIGN KEY (sport_location_id)
REFERENCES dms_sample.sport_location (id)
ON DELETE NO ACTION; 

ALTER TABLE dms_sample.sporting_event
ADD CONSTRAINT se_location_id_fk FOREIGN KEY (location_id)
REFERENCES dms_sample.sport_location (id)
ON DELETE NO ACTION;
```

error out  when sct is used
error is
```
ERROR:  foreign key constraint "s_sport_location_fk" cannot be implemented
DETAIL:  Key columns "sport_location_id" and "id" are of incompatible types: double precision and numeric.

ERROR:  foreign key constraint "se_location_id_fk" cannot be implemented
DETAIL:  Key columns "location_id" and "id" are of incompatible types: double precision and numeric.
```

The above change fixes the issue